### PR TITLE
fix: rename divider to separator

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -67,7 +67,7 @@
         />
       </div>
 
-      <UDivider v-if="filteredVideos.length !== videos.length" />
+      <USeparator v-if="filteredVideos.length !== videos.length" />
 
       <div
         v-if="filteredVideos.length !== videos.length"


### PR DESCRIPTION
Hello 👋,

The [`Divider`](https://ui2.nuxt.com/components/divider) component from Nuxt UI 2 has been renamed to [`Separator`](https://ui.nuxt.com/components/separator) in Nuxt UI 3.
