### PR TITLE
fix: layout shift

### DIFF
--- a/app/pages/videos/[slug].vue
+++ b/app/pages/videos/[slug].vue
@@ -84,6 +84,7 @@
           :items="items"
           color="primary"
           class="mt-6"
+          :unmount-on-hide="false"
         >
           <template #description>
             <div class="max-w-none pt-4">


### PR DESCRIPTION
Hello 👋,

This PR fixes a layout shift that occurs when navigating from 'liens utiles' to 'description'.

Before

https://github.com/user-attachments/assets/cea8b3bc-196f-4abf-a162-5b9045dcb4dc

After

https://github.com/user-attachments/assets/9d5ccb68-48a8-42bb-957e-9d5c58f618b3

